### PR TITLE
Add simple= helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # utils.test [![CircleCI](https://circleci.com/gh/nedap/utils.test.svg?style=svg&circle-token=40d5b1ddb5290559200d8569aeeba8ef70ef1883)](https://circleci.com/gh/nedap/utils.test)
 
-(In short: What does the library do?)
+A collection of test helpers.
 
 ## Synopsis
 
-(Show off its main functions so the reader can get a basic idea)
+`nedap.utils.test.api/simplify` allows you to transform complex data for ease in comparison in tests. 
+It transforms `Sequential` collections into sets and `IPersistentMap` into plain maps.
+
+The [api test](test/unit/nedap/utils/test/api.cljc) shows a couple examples with records.
 
 ## Installation
 
@@ -14,7 +17,8 @@
 
 ## ns organisation
 
-(how is the project organised? Which are its public parts?)
+There is exactly 1 namespace meant for public consumption:
+ - nedap.utils.test.api
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of test helpers.
 
 ## Synopsis
 
-`nedap.utils.test.api/simplify` allows you to transform complex data for ease in comparison in tests. 
+`nedap.utils.test.api/simple=` allows you to compare similar structure disregarding possible order.
 It transforms `Sequential` collections into sets and `IPersistentMap` into plain maps.
 
 The [api test](test/unit/nedap/utils/test/api.cljc) shows a couple examples with records.
@@ -18,7 +18,7 @@ The [api test](test/unit/nedap/utils/test/api.cljc) shows a couple examples with
 ## ns organisation
 
 There is exactly 1 namespace meant for public consumption:
- - nedap.utils.test.api
+ - `nedap.utils.test.api`
 
 ## Documentation
 

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -4,7 +4,9 @@
    [nedap.utils.speced :as speced]))
 
 (speced/defn ^any? simplify
-  "Transforms records into maps and Sequential collections into sets, identity otherwise."
+  "Transforms records into maps and Sequential collections into sets, identity otherwise.
+
+  note: this will remove duplicates"
   [^any? val]
   (walk/postwalk
    (fn [node]

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -1,1 +1,16 @@
-(ns nedap.utils.test.api)
+(ns nedap.utils.test.api
+  (:require
+   [clojure.walk :as walk]
+   [nedap.utils.speced :as speced]))
+
+(speced/defn ^any? simplify
+  "Transforms records into maps and Sequential collections into sets, identity otherwise."
+  [^any? val]
+  (walk/postwalk
+   (fn [node]
+     (cond
+       (map? node)        (into {} node)
+       (map-entry? node)  node       ;; Keep map entries as is
+       (sequential? node) (set node) ;; Make collections into a set to prevent ordering issues
+       :else              node))
+   val))

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -1,18 +1,10 @@
 (ns nedap.utils.test.api
   (:require
-   [clojure.walk :as walk]
-   [nedap.utils.speced :as speced]))
+   [nedap.utils.test.impl :as impl]))
 
-(speced/defn ^any? simplify
-  "Transforms records into maps and Sequential collections into sets, identity otherwise.
+(defn simple=
+  "Check whether all `vals` have similar structure disregarding possible order
 
-  note: this will remove duplicates"
-  [^any? val]
-  (walk/postwalk
-   (fn [node]
-     (cond
-       (map? node)        (into {} node)
-       (map-entry? node)  node       ;; Keep map entries as is
-       (sequential? node) (set node) ;; Make collections into a set to prevent ordering issues
-       :else              node))
-   val))
+  NOTE: this function will disregard duplicates"
+  [& vals]
+  (apply = (map impl/simplify vals)))

--- a/src/nedap/utils/test/impl.cljc
+++ b/src/nedap/utils/test/impl.cljc
@@ -1,0 +1,17 @@
+(ns nedap.utils.test.impl
+  (:require
+   [clojure.walk :as walk]))
+
+(defn simplify
+  "Transforms records into maps and Sequential collections into sets, identity otherwise.
+
+  NOTE: this will remove duplicates"
+  [val]
+  (walk/postwalk
+   (fn [node]
+     (cond
+       (map? node)        (into {} node)
+       (map-entry? node)  node       ;; Keep map entries as is
+       (sequential? node) (set node) ;; Make collections into a set to prevent ordering issues
+       :else              node))
+   val))

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -4,46 +4,24 @@
       :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
    [nedap.utils.test.api :as sut]))
 
-(deftest simplify
-  (are [input expected] (= expected
-                           (sut/simplify input))
-    nil
-    nil
-
-    [:a :b :c]
-    #{:c :b :a}
-
-    [:a :b :b :c]
-    #{:a :b :c}
-
-    {:key [:a :b :c]}
-    {:key #{:a :c :b}}
-
-    {:key :value}
-    {:key :value}
-
-    {:nested {:key [:value]}}
-    {:nested {:key #{:value}}}
-
-    {:nested {:key :value}}
-    {:nested {:key :value}}))
-
 (defrecord Student  [name])
 (defrecord School [students])
 
-(deftest record-comparing
-  (let [data     {:students #{{:name "Luna Lovegood"}
-                              {:name "Neville Longbottom"}
-                              {:name "Harry Potter"}}}
-        hogwarts (->School [(->Student "Luna Lovegood")
-                            (->Student "Neville Longbottom")
-                            (->Student "Harry Potter")])
-        simplified (sut/simplify hogwarts)]
+(deftest =simple
+  (testing "Assert behaviour of simple="
+    (are [a b] (sut/simple= a b)
+      [:a :b :b :c]
+      #{:a :b :c}
 
-    (testing "record comparison"
-      (is (not= data hogwarts))
-      (is (= data simplified)))
+      {:key [:c :b :a]}
+      {:key #{:a :c :b}}
 
-    (testing "partial matches"
-      (is (:students simplified)
-          {:name "Harry Potter"}))))
+      {:nested {:key [:value :other]}}
+      {:nested {:key #{:other :value}}}
+
+      {:students #{{:name "Luna Lovegood"}
+                   {:name "Neville Longbottom"}
+                   {:name "Harry Potter"}}}
+      (->School [(->Student "Luna Lovegood")
+                 (->Student "Neville Longbottom")
+                 (->Student "Harry Potter")]))))

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -7,7 +7,7 @@
 (defrecord Student  [name])
 (defrecord School [students])
 
-(deftest =simple
+(deftest simple=
   (testing "Assert behaviour of simple="
     (are [a b] (sut/simple= a b)
       [:a :b :b :c]

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -1,8 +1,8 @@
 (ns unit.nedap.utils.test.api
- (:require
-  #?(:clj  [clojure.test :refer [deftest testing are is use-fixtures]]
-     :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
-  [nedap.utils.test.api :as sut]))
+  (:require
+   #?(:clj  [clojure.test :refer [deftest testing are is use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   [nedap.utils.test.api :as sut]))
 
 (deftest simplify
   (are [input expected] (= expected

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -4,5 +4,43 @@
      :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
   [nedap.utils.test.api :as sut]))
 
-(deftest fixme
-  (is (= 1 2)))
+(deftest simplify
+  (are [input expected] (= expected
+                           (sut/simplify input))
+    nil
+    nil
+
+    [:a :b :c]
+    #{:c :b :a}
+
+    {:key [:a :b :c]}
+    {:key #{:a :c :b}}
+
+    {:key :value}
+    {:key :value}
+
+    {:nested {:key [:value]}}
+    {:nested {:key #{:value}}}
+
+    {:nested {:key :value}}
+    {:nested {:key :value}}))
+
+(defrecord Student  [name])
+(defrecord School [students])
+
+(deftest record-comparing
+  (let [data     {:students #{{:name "Luna Lovegood"}
+                              {:name "Neville Longbottom"}
+                              {:name "Harry Potter"}}}
+        hogwarts (->School [(->Student "Luna Lovegood")
+                            (->Student "Neville Longbottom")
+                            (->Student "Harry Potter")])
+        simplified (sut/simplify hogwarts)]
+
+    (testing "record comparison"
+      (is (not= data hogwarts))
+      (is (= data simplified)))
+
+    (testing "partial matches"
+      (is (:students simplified)
+          {:name "Harry Potter"}))))

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -13,6 +13,9 @@
     [:a :b :c]
     #{:c :b :a}
 
+    [:a :b :b :c]
+    #{:a :b :c}
+
     {:key [:a :b :c]}
     {:key #{:a :c :b}}
 

--- a/test/unit/nedap/utils/test/impl.cljc
+++ b/test/unit/nedap/utils/test/impl.cljc
@@ -1,0 +1,30 @@
+(ns unit.nedap.utils.test.impl
+  (:require
+   #?(:clj  [clojure.test :refer [deftest testing are is use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   [nedap.utils.test.impl :as sut]))
+
+(deftest simplify
+  (testing "assert expected transformations by simplify"
+    (are [input expected] (= expected
+                             (sut/simplify input))
+      nil
+      nil
+
+      [:a :b :c]
+      #{:c :b :a}
+
+      [:a :b :b :c]
+      #{:a :b :c}
+
+      {:key [:a :b :c]}
+      {:key #{:a :c :b}}
+
+      {:key :value}
+      {:key :value}
+
+      {:nested {:key [:value]}}
+      {:nested {:key #{:value}}}
+
+      {:nested {:key :value}}
+      {:nested {:key :value}})))


### PR DESCRIPTION
## Brief
Adds `nedap.utils.test/simplify`; helper for easy comparison of complex data.
 - [forester use case](https://github.com/nedap/pep-forester/blob/3b67d0767fa13962736898f2c0954173409ea4a8/modules/forester/events/test/editing.clj#L33-L53): comparing records to data
 - [flow use case](https://github.com/nedap/pep-flow/blob/deae55a63ce1937b9f98751a137e5dcab8003b3a/test/pep_flow/integration/components/graphql_schema_provider.clj#L33-L38): removing order from graphql result

## QA plan
 - [ ] Add in `postman-events`-branch on forester (instead of https://github.com/nedap/pep-forester/pull/130/files)

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] I have self-reviewed the PR prior to assignment, and its build passes
* Specifically, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Business-facing correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Cross-compatibility (Clojure/ClojureScript)
