### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "0.1.0-alpha1"]
+[com.nedap.staffing-solutions/utils.test "1.0.0"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/utils.test "0.1.0-alpha1"
+(defproject com.nedap.staffing-solutions/utils.test "1.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.0"]]
 


### PR DESCRIPTION
Release 1.0.0. Already tagged + pushed. Removed previous tag (https://github.com/nedap/utils.test/pull/5 and https://github.com/nedap/utils.test/pull/6 attempts)

As per semver, pre-1.0.0 chaos is permitted, which we should avoid for a lib tests will rely on
