### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "1.0.0"]
+[com.nedap.staffing-solutions/utils.test "1.1.0"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/utils.test "1.0.0"
+(defproject com.nedap.staffing-solutions/utils.test "1.1.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.0"]]
 


### PR DESCRIPTION
No changes. 1.0.0 was a haunted release (see https://github.com/nedap/utils.spec/pull/59)

Cause was bad combination of:

* vemv fat fingers
* JFrog mutable releases