### PR TITLE
Add ref-changed? matcher

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,7 @@
   :profiles {:dev      {:dependencies [[cider/cider-nrepl "0.16.0" #_"formatting-stack needs it"]
                                        [com.clojure-goes-fast/clj-java-decompiler "0.2.1"]
                                        [criterium "0.4.4"]
-                                       [formatting-stack "0.18.2"]
+                                       [formatting-stack "0.18.3"]
                                        [lambdaisland/deep-diff "0.0-29"]
                                        [org.clojure/tools.namespace "0.3.0-alpha4"]
                                        [org.clojure/tools.reader "1.1.1" #_"formatting-stack needs it"]]

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -1,6 +1,7 @@
 (ns nedap.utils.test.api
   (:require
    [clojure.walk :as walk]
+   #?(:clj [clojure.test :as test])
    [nedap.utils.test.impl :as impl])
   #?(:clj (:import (clojure.lang IMeta))))
 
@@ -38,3 +39,15 @@
   (letfn [(r [tree]
             (walk/postwalk impl/replace-gensyms tree))]
     (->> xs (map r) (apply =))))
+
+#?(:clj ;; TODO name
+   (defmethod test/assert-expr 'ref-changed? [msg form]
+     ;; (is (ref-changed? a expr))
+     ;; (is (ref-changed? a expr :to v :timeout 100))
+     ;; Asserts that evaluating expr changes reference a to value v.
+     ;; both :to and :timeout are optional
+     (let [reference     (second form)
+           body          (first (nthnext form 2))
+           {:as options} (nthnext form 3)]
+       `(let [result# (impl/ref-changed ~reference ~body ~options)]
+          (test/do-report (assoc result# :message ~msg))))))

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -110,3 +110,9 @@
       (gensym)         42
       (gensym)         nil
       [[1 (gensym) 2]] [[1 (gensym) 3]])))
+
+#?(:clj
+   (deftest ref-changed?-defmethod
+     (let [a (atom {})]
+       (is (ref-changed? a (swap! a assoc :value 1)))
+       (is (ref-changed? a (swap! a assoc :value 2) :to {:value 2})))))

--- a/test/unit/nedap/utils/test/impl.cljc
+++ b/test/unit/nedap/utils/test/impl.cljc
@@ -1,7 +1,6 @@
 (ns unit.nedap.utils.test.impl
   (:require
-   #?(:clj  [clojure.test :refer [deftest testing are is use-fixtures]]
-      :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
    [nedap.utils.test.impl :as sut]))
 
 (deftest simplify
@@ -28,3 +27,32 @@
 
       {:nested {:key :value}}
       {:nested {:key :value}})))
+
+#?(:clj
+   (deftest ref-changed
+     (are [form options expected] (= expected
+                                     (let [ref (atom {})]
+                                       (sut/ref-changed ref form options)))
+       (swap! ref assoc :value 1)
+       {:to {:value 1}}
+       {:type :pass
+        :expected {:value 1}
+        :actual {:value 1}}
+
+       (swap! ref assoc :value 1)
+       {}
+       {:type     :pass
+        :expected ::sut/changed
+        :actual   ::sut/changed}
+
+       (swap! ref assoc :value 2)
+       {:to {:value 1}}
+       {:type :fail
+        :expected {:value 1}
+        :actual {:value 2}}
+
+       (constantly true)
+       {:to {:value 1} :timeout 1}
+       {:type :fail
+        :expected {:value 1}
+        :actual ::sut/timed-out})))


### PR DESCRIPTION
## Brief
Testing async behavior is a pain, this helper allows you to assert changing references:
https://github.com/nedap/utils.test/blob/56df9d0ac452c980bca28abbe92cfa7a33abc52d/test/unit/nedap/utils/test/api.cljc#L116-L118

In https://github.com/nedap/postman-clj/pull/32 I'm adding a full-stack tests for publishing a message to kafka, and asserting it's dispatched to the right handler has multiple layers of asynchronousness :P 

These tests now look like;
```clj
(deftest consuming
  (let [last-msg  (:last-message (register-handler "LocationEvent"))
        last-msg2 (:last-message (register-handler "LocationEvent2"))]
    (is (ref-changed? last-msg  (send! message) :to message :timeout 6000))
    (is (ref-changed? last-msg2 (send! message) :to :utils.test/timed-out :timeout 6000))))
```

## QA plan
Green tests, suggestion for naming

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] I have self-reviewed the PR prior to assignment, and its build passes
* Specifically, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [x] Security
  * [x] Performance
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Business-facing correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Cross-compatibility (Clojure/ClojureScript)
