### PR TITLE
v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "1.6.0"]
+[com.nedap.staffing-solutions/utils.test "1.6.1"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.test "1.6.0"
+(defproject com.nedap.staffing-solutions/utils.test "1.6.1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.1"]]
 


### PR DESCRIPTION
deprecates `simple=`, adds synopsis for `expect`