### PR TITLE
Exit code setting for cljs: respect prior decisions for failing the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
           name: 'Run JVM tests, reporting coverage'
           command: lein with-profile -dev,+test trampoline cloverage --lcov --junit -o coverage/
       - run:
-          name: 'Ensure production isolation'
-          command: lein with-profile -dev check
+          name: 'Ensure production isolation, check for boxed math'
+          command: lein with-profile -dev,+check check
       - store_test_results:
           path: ~/repo/coverage
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -32,5 +32,4 @@ You can find examples in the [api test](test/unit/nedap/utils/test/api.cljc).
 ## License
 
 Copyright © Nedap
-
-This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is available at http://www.eclipse.org/legal/epl-2.0.
+This program and the accompanying materials are made available under the terms of the [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0)

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -5,13 +5,12 @@
    [clojure.pprint :refer [pprint]]
    [clojure.repl :refer [apropos dir doc find-doc pst source]]
    [clojure.test :refer [run-all-tests run-tests]]
-   [clojure.tools.namespace.repl :refer [refresh set-refresh-dirs]]
+   [clojure.tools.namespace.repl :refer [clear refresh refresh-dirs set-refresh-dirs]]
    [criterium.core :refer [quick-bench]]
    [formatting-stack.branch-formatter :refer [format-and-lint-branch! lint-branch!]]
    [formatting-stack.compilers.test-runner :refer [test!]]
    [formatting-stack.project-formatter :refer [format-and-lint-project! lint-project!]]
-   [lambdaisland.deep-diff]
-   [nedap.utils.test.api :refer :all]))
+   [lambdaisland.deep-diff]))
 
 (set-refresh-dirs "src" "test" "dev")
 

--- a/nedap.lein-template.properties
+++ b/nedap.lein-template.properties
@@ -1,0 +1,11 @@
+nedap.lein-template.github_username=nedap
+nedap.lein-template.copyright_holder=Nedap
+nedap.lein-template.group_id=com.nedap.staffing-solutions
+nedap.lein-template.lib_prefix=nedap.utils.test
+nedap.lein-template.gpg_email=releases-staffingsolutions@nedap.com
+nedap.lein-template.use_system=false
+nedap.lein-template.use_cljs=true
+nedap.lein-template.use_clojars=true
+nedap.lein-template.do_license=true
+nedap.lein-template.use_nvd=false
+nedap.lein-template.use_pedestal=false

--- a/project.clj
+++ b/project.clj
@@ -59,14 +59,14 @@
                                        [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]
                                        [com.stuartsierra/component "0.4.0"]
                                        [com.taoensso/timbre "4.10.0"]
-                                       [criterium "0.4.4"]
-                                       [formatting-stack "1.0.0"]
+                                       [criterium "0.4.5"]
+                                       [formatting-stack "1.0.1"]
                                        [lambdaisland/deep-diff "0.0-29"]
                                        [medley "1.2.0"]
                                        [org.clojure/core.async "0.5.527"]
                                        [org.clojure/math.combinatorics "0.1.1"]
                                        [org.clojure/test.check "0.10.0-alpha3"]
-                                       [org.clojure/tools.namespace "0.3.0-alpha4"]]
+                                       [org.clojure/tools.namespace "0.3.1"]]
                         :plugins      [[lein-cloverage "1.1.1"]]
                         :source-paths ["dev"]
                         :repl-options {:init-ns dev}}
@@ -75,14 +75,20 @@
                                         :exclusions [com.cognitect/transit-clj
                                                      com.google.code.findbugs/jsr305
                                                      com.google.errorprone/error_prone_annotations]]
+                                       [com.google.guava/guava "25.1-jre" #_"transitive"]
+                                       [com.google.protobuf/protobuf-java "3.4.0" #_"transitive"]
                                        [com.cognitect/transit-clj "0.8.313" #_"transitive"]
                                        [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
                                        [com.google.code.findbugs/jsr305 "3.0.2" #_"transitive"]]}
 
+             :check    {:global-vars {*unchecked-math* :warn-on-boxed
+                                      ;; avoid warnings that cannot affect production:
+                                      *assert*         false}}
+
              :test     {:dependencies [[com.nedap.staffing-solutions/matcher-combinators "1.1.0-alpha1"
-                                        :exclusions [commons-codec]]
-                                       [com.nedap.staffing-solutions/utils.test "1.6.1"]]
-                        :jvm-opts     ["-Dclojure.core.async.go-checking=true"]}
+                                        :exclusions [commons-codec]]]
+                        :jvm-opts     ["-Dclojure.core.async.go-checking=true"
+                                       "-Duser.language=en-US"]}
 
              :ci       {:pedantic?    :abort
                         :jvm-opts     ["-Dclojure.main.report=stderr"]

--- a/src/nedap/utils/test/impl.cljc
+++ b/src/nedap/utils/test/impl.cljc
@@ -53,10 +53,16 @@
 #?(:cljs
    (do
      (derive ::exit-code-reporter :cljs.test/default)
+
+     (defn set-exit-code-for! [summary process-object]
+       (assert (map? summary))
+       (if-not (cljs.test/successful? summary)
+         (set! (.-exitCode process-object) 1)
+         (when-not (.-exitCode process-object)
+           (set! (.-exitCode process-object) 0))))
+
      (defmethod cljs.test/report [::exit-code-reporter :end-run-tests] [summary]
-       (if (cljs.test/successful? summary)
-         (set! (.-exitCode js/process) 0)
-         (set! (.-exitCode js/process) 1)))))
+       (set-exit-code-for! summary js/process))))
 
 (defn expect
   [bodies {:keys [to-change from to] :as opts} clj?]

--- a/test/unit/nedap/utils/test/impl.cljc
+++ b/test/unit/nedap/utils/test/impl.cljc
@@ -1,7 +1,6 @@
 (ns unit.nedap.utils.test.impl
   (:require
-   #?(:clj  [clojure.test :refer [deftest testing are is use-fixtures]]
-      :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
    [nedap.utils.test.impl :as sut]))
 
 (deftest simplify
@@ -28,3 +27,27 @@
 
       {:nested {:key :value}}
       {:nested {:key :value}})))
+
+(def successful-summary {:fail 0, :error 0})
+
+(def unsuccessful-summary {:fail 1, :error 1})
+
+#?(:cljs
+   (deftest set-exit-code-for!
+     (are [summary existing-code expected] (testing [summary existing-code]
+                                             (let [process-object (js-obj "exitCode" existing-code)]
+                                               (sut/set-exit-code-for! summary process-object)
+                                               (is (= expected
+                                                      (-> process-object .-exitCode))))
+                                             true)
+       successful-summary   nil 0
+       successful-summary   -1  -1
+       successful-summary   0   0
+       successful-summary   1   1
+       successful-summary   42  42
+
+       unsuccessful-summary nil 1
+       unsuccessful-summary -1  1
+       unsuccessful-summary 0   1
+       unsuccessful-summary 1   1
+       unsuccessful-summary 42  1)))


### PR DESCRIPTION
## Brief

Code such as error-handling callbacks (particularly for async code) may decide to fail builds with a non-zero exit code.

It's important to not overwrite those decisions with a 0: else a given build would spuriously succeed.

I think that `1` _can_ overwrite an existing non-zero though: neither value is more important than the other.

## QA plan

* Add this code in a deftest:

```clj
#?(:cljs (deftest xxx
           (set! (.-exitCode js/process) 9)))
```

* Run the cljs test suite

* `echo $?` will say `9`
  * Whereas it'd be 0 in `master`

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
