### PR TITLE
add :with option to expect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v1-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: lein with-profile -dev,+test,+ci deps
+      - run: lein with-profile -dev,+test,+ci,+ncrw deps
       - save_cache:
           paths:
             - ~/.m2
@@ -87,7 +87,7 @@ jobs:
           command: echo -e "$GPG_KEY_V2" | gpg --import
       - run:
           name: Perform pre-release sanity check
-          command: lein with-profile -dev,+ci run -m nedap.ci.release-workflow.api sanity-check
+          command: lein with-profile -dev,+ci,+ncrw run -m nedap.ci.release-workflow.api sanity-check
       - run:
           name: release to JFrog
           command: lein deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v1-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: lein with-profile -dev,+test,+ci,+ncrw deps
+      - run: lein with-profile -dev,+test,+ci deps
       - save_cache:
           paths:
             - ~/.m2

--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,8 @@
                         :jvm-opts     ["-Dclojure.core.async.go-checking=true"
                                        "-Duser.language=en-US"]}
 
+             :ncrw       {:global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
+                          :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.11.0"]]}
+
              :ci       {:pedantic?    :abort
-                        :jvm-opts     ["-Dclojure.main.report=stderr"]
-                        :global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
-                        :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.7.0-alpha3"]]}})
+                        :jvm-opts     ["-Dclojure.main.report=stderr"]}})

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
                                        [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
                                        [com.google.guava/guava "25.1-jre" #_"transitive"]
                                        [com.google.protobuf/protobuf-java "3.4.0" #_"transitive"]
-                                       [nubank/matcher-combinators "3.1.3"
+                                       [nubank/matcher-combinators "3.1.4"
                                         :exclusions [org.clojure/spec.alpha
                                                      commons-codec]]]}
 

--- a/project.clj
+++ b/project.clj
@@ -78,12 +78,15 @@
                                                      com.google.code.findbugs/jsr305
                                                      com.google.errorprone/error_prone_annotations
                                                      org.clojure/tools.reader]]
+                                       [com.cognitect/transit-clj "0.8.313" #_"transitive"]
                                        [com.fasterxml.jackson.core/jackson-core "2.9.6" #_"transitive"]
+                                       [com.google.code.findbugs/jsr305 "3.0.2" #_"transitive"]
+                                       [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
                                        [com.google.guava/guava "25.1-jre" #_"transitive"]
                                        [com.google.protobuf/protobuf-java "3.4.0" #_"transitive"]
-                                       [com.cognitect/transit-clj "0.8.313" #_"transitive"]
-                                       [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
-                                       [com.google.code.findbugs/jsr305 "3.0.2" #_"transitive"]]}
+                                       [nubank/matcher-combinators "3.1.3"
+                                        :exclusions [org.clojure/spec.alpha
+                                                     commons-codec]]]}
 
              :check    {:global-vars  {*unchecked-math* :warn-on-boxed
                                        ;; avoid warnings that cannot affect production:
@@ -99,9 +102,7 @@
              :jdk11      {:dependencies [[javax.xml.bind/jaxb-api "2.3.1"]
                                          [org.glassfish.jaxb/jaxb-runtime "2.3.1"]]}
 
-             :test     {:dependencies [[com.nedap.staffing-solutions/matcher-combinators "1.1.0-alpha1"
-                                        :exclusions [commons-codec]]]
-                        :jvm-opts     ["-Dclojure.core.async.go-checking=true"
+             :test     {:jvm-opts     ["-Dclojure.core.async.go-checking=true"
                                        "-Duser.language=en-US"]}
 
              :ncrw       {:global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                                    :password :env/clojars_pass}}
   :target-path "target/%s"
 
-  :test-paths ["src" "test"]
+  :test-paths ["test"]
 
   :monkeypatch-clojure-test false
 

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -59,7 +59,7 @@
     (impl/expect bodies (merge defaults options) clj?)))
 
 (defmethod impl/expect-matcher 'meta= [_]
-  {:pred-sym-failure "`to-change` does not equal `to`: (not (meta= %s %s))"
+  {:pred-sym-failure "`to-change` does not equal `from`: (not (meta= %s %s))"
    :pred-failure "`from` is not allowed to equal `to`: %s"
    :assert-expr-sym `meta=
    :pred-sym `meta=

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -42,7 +42,8 @@
     `(cljs.test/run-tests (cljs.test/empty-env ::impl/exit-code-reporter) ~@namespaces)))
 
 (defmacro expect
-  "Asserts (via `#'clojure.test/is`) that the expression denoted by `to-change` changes from `from`, to `to` using `with`.
+  "Asserts (via `#'clojure.test/is`) that the expression denoted by `to-change` changes from `from`, to `to`.
+   The equality comparator can be overridden with `with`.`.
 
   `(expect (swap! a inc) :to-change @a :from 1 :to 2)`"
   [& forms]
@@ -53,6 +54,11 @@
                      (reduce (fn [memo [v k]]
                                (assoc memo k v)) {}))
         bodies  (drop-last (* 2 (count options)) forms)
-        defaults {:with `meta=}
+        defaults {:with 'meta=}
         clj?    (-> &env :ns nil?)]
-    (impl/expect bodies (merge defaults options) clj? *ns*)))
+    (impl/expect bodies (merge defaults options) clj?)))
+
+(defmethod impl/expect-matcher 'meta= [_]
+  {:assert-expr-sym `meta=
+   :pred-sym `meta=
+   :pred meta=})

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -42,15 +42,16 @@
     `(cljs.test/run-tests (cljs.test/empty-env ::impl/exit-code-reporter) ~@namespaces)))
 
 (defmacro expect [& forms]
-  "Asserts (via `#'clojure.test/is`) that the expression denoted by `to-change` changes from `from`, to `to`.
+  "Asserts (via `#'clojure.test/is`) that the expression denoted by `to-change` changes from `from`, to `to` using `with`.
 
   `(expect (swap! a inc) :to-change @a :from 1 :to 2)`"
   (let [options (->> (reverse forms)
                      (partition 2)
-                     (take-while (fn [[_val key]]
-                                   (keyword? key)))
-                     (reduce (fn [memo [val key]]
-                               (assoc memo key val)) {}))
+                     (take-while (fn [[_v k]]
+                                   (keyword? k)))
+                     (reduce (fn [memo [v k]]
+                               (assoc memo k v)) {}))
         bodies  (drop-last (* 2 (count options)) forms)
+        defaults {:with `meta=}
         clj?    (-> &env :ns nil?)]
-    (impl/expect bodies options clj?)))
+    (impl/expect bodies (merge defaults options) clj? *ns*)))

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -59,6 +59,8 @@
     (impl/expect bodies (merge defaults options) clj?)))
 
 (defmethod impl/expect-matcher 'meta= [_]
-  {:assert-expr-sym `meta=
+  {:pred-sym-failure "`to-change` does not equal `to`: (not (meta= %s %s))"
+   :pred-failure "`from` is not allowed to equal `to`: %s"
+   :assert-expr-sym `meta=
    :pred-sym `meta=
    :pred meta=})

--- a/src/nedap/utils/test/api.cljc
+++ b/src/nedap/utils/test/api.cljc
@@ -41,10 +41,11 @@
     `(clojure.test/run-tests ~@namespaces)
     `(cljs.test/run-tests (cljs.test/empty-env ::impl/exit-code-reporter) ~@namespaces)))
 
-(defmacro expect [& forms]
+(defmacro expect
   "Asserts (via `#'clojure.test/is`) that the expression denoted by `to-change` changes from `from`, to `to` using `with`.
 
   `(expect (swap! a inc) :to-change @a :from 1 :to 2)`"
+  [& forms]
   (let [options (->> (reverse forms)
                      (partition 2)
                      (take-while (fn [[_v k]]

--- a/src/nedap/utils/test/impl.cljc
+++ b/src/nedap/utils/test/impl.cljc
@@ -78,7 +78,7 @@
           identity)
 
 (defmethod expect-matcher '= [_]
-  {:pred-sym-failure "`to-change` does not equal `to`: (not (= %s %s))"
+  {:pred-sym-failure "`to-change` does not equal `from`: (not (= %s %s))"
    :pred-failure "`from` is not allowed to equal `to`: %s"
    :assert-expr-sym '=
    :pred-sym `=

--- a/src/nedap/utils/test/impl.cljc
+++ b/src/nedap/utils/test/impl.cljc
@@ -86,7 +86,12 @@
   (assert (= #{:to-change :from :to} (set (keys (dissoc opts :with)))) (pr-str opts))
   (let [{:keys [pred-sym pred assert-expr-sym]} (expect-matcher with)
         is (if clj? 'clojure.test/is 'cljs.test/is)]
-    (assert (every? some? [pred-sym pred assert-expr-sym]))
+    (assert (ifn? pred)
+            (str "invalid :pred registered for: " with ", got: " (pr-str pred)))
+    (assert (qualified-symbol? pred-sym)
+            (str "invalid :pred-sym registered for: " with ", got: " (pr-str pred-sym)))
+    (assert (symbol? assert-expr-sym)
+            (str "invalid :assert-expr-sym registered for: " with ", got: " (pr-str assert-expr-sym)))
     (assert (not (pred from to))
             (binding [*print-meta* true]
               (str (pr-str from) " should not match " (pr-str to))))

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -3,8 +3,8 @@
    #?(:clj [clojure.test :refer [do-report run-tests deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are run-tests] :refer [use-fixtures do-report]])
    [clojure.string :as string]
    [matcher-combinators.test :refer [match?]]
-   [nedap.utils.test.impl :as impl]
-   [nedap.utils.test.api :as sut])
+   [nedap.utils.test.api :as sut]
+   [nedap.utils.test.impl :as impl])
   #?(:clj (:import (clojure.lang ExceptionInfo Compiler$CompilerException))))
 
 (defrecord Student  [name])

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -257,10 +257,10 @@
                "invalid :pred registered for: missing-pred, got: nil"
                `(sut/expect () :to-change 0 :from 0 :to 1 :with ~'missing-pred)
 
-               "`to-change` does not equal `to`: (not (meta= 0 1))"
+               "`to-change` does not equal `from`: (not (meta= 0 1))"
                `(sut/expect () :to-change 0 :from 1 :to 2)
 
-               "`to-change` does not equal `to`: (not (= 0 1))"
+               "`to-change` does not equal `from`: (not (= 0 1))"
                `(sut/expect () :to-change 0 :from 1 :to 2 :with ~'=)))
 
            (testing "asserts at least one body"

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -1,6 +1,7 @@
 (ns unit.nedap.utils.test.api
   (:require
-   #?(:clj [clojure.test :refer [do-report run-tests deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are run-tests] :refer [use-fixtures do-report]])
+   #?(:clj [clojure.test :refer [do-report run-tests deftest testing are is use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest testing is are run-tests] :refer [use-fixtures do-report]])
    [clojure.string :as string]
    [matcher-combinators.test :refer [match?]]
    [nedap.utils.test.api :as sut]
@@ -129,6 +130,14 @@
                   :from 1
                   :to 3)))
 
+  (testing ":with `clojure.test/=`"
+    (let [a (atom 0)]
+      (sut/expect (swap! a inc)
+                  :with =
+                  :to-change @a
+                  :from 0
+                  :to 1)))
+
   (testing "the macroexpansion evaluation"
     (let [proof (atom [])]
       (sut/expect
@@ -174,7 +183,14 @@
           `{:type :fail, :expected (sut/meta= {} {}), :actual (~'not (sut/meta= {} {}))}
 
           (sut/expect (swap! a inc) :to-change @a :from 0 :to 2)
-          `{:type :fail, :expected (sut/meta= (deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}))))
+          `{:type :fail, :expected (sut/meta= (deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}
+
+           ;; change matcher to `=`
+          (sut/expect 0 :with = :to-change 0 :from 0 :to 1)
+          `{:type :fail, :expected (~'= 0 1), :actual (~'not (~'= 0 1))}
+
+          (sut/expect (swap! a inc) :with = :to-change @a :from 1 :to 3)
+          `{:type :fail, :expected (~'= (deref ~'a) 3), :actual ~'(not (= 2 3))}))))
 
   #?(:clj
      (when *assert*

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -182,14 +182,14 @@
           `{:type :fail, :expected (sut/meta= {} {}), :actual (~'not (sut/meta= {} {}))}
 
           (sut/expect (swap! a inc) :to-change @a :from 0 :to 2)
-          `{:type :fail, :expected (sut/meta= (deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}
+          `{:type :fail, :expected (sut/meta= (~'clojure.core/deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}
 
            ;; change matcher to `=`
           (sut/expect 0 :to-change 0 :from 0 :to 1 :with =)
           `{:type :fail, :expected (~'= 0 1), :actual ~'(not (= 0 1))}
 
           (sut/expect (swap! a inc) :to-change @a :from 1 :to 3 :with =)
-          `{:type :fail, :expected (~'= (deref ~'a) 3), :actual ~'(not (= 2 3))}))))
+          `{:type :fail, :expected (~'= (~'clojure.core/deref ~'a) 3), :actual ~'(not (= 2 3))}))))
 
   #?(:clj
      (when *assert*

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -1,7 +1,6 @@
 (ns unit.nedap.utils.test.api
   (:require
-   #?(:clj [clojure.test :refer [do-report run-tests deftest testing are is use-fixtures]]
-      :cljs [cljs.test :refer-macros [deftest testing is are run-tests] :refer [use-fixtures do-report]])
+   #?(:clj [clojure.test :refer [do-report run-tests deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are run-tests] :refer [use-fixtures do-report]])
    [clojure.string :as string]
    [matcher-combinators.test :refer [match?]]
    [nedap.utils.test.api :as sut]
@@ -133,10 +132,10 @@
   (testing ":with `clojure.test/=`"
     (let [a (atom 0)]
       (sut/expect (swap! a inc)
-                  :with =
                   :to-change @a
                   :from 0
-                  :to 1)))
+                  :to 1
+                  :with =)))
 
   (testing "the macroexpansion evaluation"
     (let [proof (atom [])]
@@ -186,10 +185,10 @@
           `{:type :fail, :expected (sut/meta= (deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}
 
            ;; change matcher to `=`
-          (sut/expect 0 :with = :to-change 0 :from 0 :to 1)
-          `{:type :fail, :expected (~'= 0 1), :actual (~'not (~'= 0 1))}
+          (sut/expect 0 :to-change 0 :from 0 :to 1 :with =)
+          `{:type :fail, :expected (~'= 0 1), :actual ~'(not (= 0 1))}
 
-          (sut/expect (swap! a inc) :with = :to-change @a :from 1 :to 3)
+          (sut/expect (swap! a inc) :to-change @a :from 1 :to 3 :with =)
           `{:type :fail, :expected (~'= (deref ~'a) 3), :actual ~'(not (= 2 3))}))))
 
   #?(:clj

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -115,6 +115,15 @@
       (gensym)         nil
       [[1 (gensym) 2]] [[1 (gensym) 3]])))
 
+;; invalid expect-matchers for testing
+(defmethod impl/expect-matcher 'wrong-pred-sym [_]
+  {:pred =
+   :pred-sym "not-a-symbol",
+   :assert-expr-sym '=,})
+(defmethod impl/expect-matcher 'missing-pred [_]
+  {:pred-sym `=,
+   :assert-expr-sym '=})
+
 (deftest expect
   (let [a (atom 0)]
     (sut/expect (swap! a inc)
@@ -224,7 +233,16 @@
                `(sut/expect () :with ~'= :to-change 0 :from 0 :to 0)
 
                "^#:unit.nedap.utils.test.api{:wat true} {} should not match ^#:unit.nedap.utils.test.api{:wat true} {}"
-               `(sut/expect () :to-change 0 :from ^::wat {} :to ^::wat {})))
+               `(sut/expect () :to-change 0 :from ^::wat {} :to ^::wat {})
+
+               "No method in multimethod 'expect-matcher' for dispatch value: unknown"
+               `(sut/expect () :to-change 0 :from 0 :to 1 :with ~'unknown)
+
+               "invalid :pred-sym registered for: wrong-pred-sym, got: \"not-a-symbol\""
+               `(sut/expect () :to-change 0 :from 0 :to 1 :with ~'wrong-pred-sym)
+
+               "invalid :pred registered for: missing-pred, got: nil"
+               `(sut/expect () :to-change 0 :from 0 :to 1 :with ~'missing-pred)))
 
            (testing "asserts at least one body"
              (is (assertion-thrown?

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -168,13 +168,13 @@
                                        form
                                        @test-result))
           (sut/expect 0 :to-change 0 :from 0 :to 1)
-          `{:type :fail, :expected (impl/meta= [0 1]), :actual (~'not (impl/meta= [0 1]))}
+          `{:type :fail, :expected (sut/meta= 0 1), :actual (~'not (sut/meta= 0 1))}
 
           (sut/expect 0 :to-change {} :from {} :to ^::test {})
-          `{:type :fail, :expected (impl/meta= [{} {}]), :actual (~'not (impl/meta= [{} {}]))}
+          `{:type :fail, :expected (sut/meta= {} {}), :actual (~'not (sut/meta= {} {}))}
 
           (sut/expect (swap! a inc) :to-change @a :from 0 :to 2)
-          `{:type :fail, :expected (impl/meta= [(deref ~'a) 2]), :actual (~'not (impl/meta= [1 2]))}))))
+          `{:type :fail, :expected (sut/meta= (deref ~'a) 2), :actual (~'not (sut/meta= 1 2))}))))
 
   #?(:clj
      (when *assert*
@@ -202,10 +202,13 @@
                "#{:to-change :from :to}"
                `(sut/expect () :unexpected () :signature 4 :keys)
 
-               "0 should be different from 0"
+               "0 should not match 0"
                `(sut/expect () :to-change 0 :from 0 :to 0)
 
-               "^#:unit.nedap.utils.test.api{:wat true} {} should be different from ^#:unit.nedap.utils.test.api{:wat true} {}"
+               "0 should not match 0"
+               `(sut/expect () :with ~'= :to-change 0 :from 0 :to 0)
+
+               "^#:unit.nedap.utils.test.api{:wat true} {} should not match ^#:unit.nedap.utils.test.api{:wat true} {}"
                `(sut/expect () :to-change 0 :from ^::wat {} :to ^::wat {})))
 
            (testing "asserts at least one body"


### PR DESCRIPTION
## Brief

Allows overriding the matcher as a consumer. The implementation is extensible by use of the multimethod.

preparation for #30.

<details>

both a predicate and assert-expr symbol are returned from the multimethod. this is because we use `(assert ...)` with a fn to do the macroexpansion-time checks, and only 1 `(is ...)` for the actual test. 


The assert requires a predicate, the `(is ...)` might need a simple symbol to hook into [clojure.test/assert-expr](https://clojuredocs.org/clojure.test/assert-expr).

</details>

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

Apply patch:
<detail>

```diff
diff --git a/test/unit/nedap/utils/test/api.cljc b/test/unit/nedap/utils/test/api.cljc
index d631fb0..0eef2ea 100644
--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -134,7 +134,7 @@
       (sut/expect (swap! a inc)
                   :to-change @a
                   :from 0
-                  :to 1
+                  :to 2
                   :with =)))
 
   (testing "the macroexpansion evaluation"
@@ -153,7 +153,7 @@
       (sut/expect (swap! proof with-meta {::test true})
                   :to-change @proof
                   :from {}
-                  :to ^::test {})
+                  :to ^::other {})
 
       (let [proof (atom ^::test {})]
         (sut/expect (swap! proof with-meta {})
```

</details>

1. run tests (clj + cljs, see .circleci/config.yml for the exact command)
1. notice 2 failures

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->
![image](https://user-images.githubusercontent.com/4689114/94900623-961c3000-0495-11eb-8e39-dada8a98cc70.png)

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
    - no cljls yet.
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
