### PR TITLE
v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "1.6.3"]
+[com.nedap.staffing-solutions/utils.test "1.7.0"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.test "1.6.3"
+(defproject com.nedap.staffing-solutions/utils.test "1.7.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.1"]]
 


### PR DESCRIPTION
Delivers: 
 - Add optional `:with` option to `expect`-macro (#31)
 - Add `match?` matcher to `expect`-macro (#32)
   - opt-in, require `nedap.utils.test.matchers`
   - also turns arguments for predicate inside `expect` around to be `(= expected actual)`

 <!-- (place here links to the included PRs/commits) -->

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [ ] New features are (briefly) reflected in the README

## Release checklist (reviewer)

* [ ] All PRs / relevant commits since the previous release are listed in this PR's description 
* [ ] The new proposed version follows semver 
* [ ] New features are (briefly) reflected in the README
