### PR TITLE
Fix failure description

### DIFF
--- a/src/nedap/utils/test/matchers.cljc
+++ b/src/nedap/utils/test/matchers.cljc
@@ -15,7 +15,7 @@
    (matcher-combinators/match this actual)))
 
 (defmethod impl/expect-matcher 'match? [_]
-  {:pred-sym-failure "`to-change` does not match? `to`: (not (match? %s %s))"
+  {:pred-sym-failure "`to-change` does not match? `from`: (not (match? %s %s))"
    :pred-failure "`from` is not allowed to equal `to`: %s"
    :assert-expr-sym 'match?
    :pred-sym `matches?

--- a/test/unit/nedap/utils/test/api.cljc
+++ b/test/unit/nedap/utils/test/api.cljc
@@ -308,7 +308,7 @@
                "`to-change` does not equal `from`: (not (= 1 0))"
                `(sut/expect () :to-change 0 :from 1 :to 2 :with ~'=)
 
-               "`to-change` does not match? `to`: (not (match? #matcher_combinators.core.InAnyOrder{:expected [1 2]} [2]))"
+               "`to-change` does not match? `from`: (not (match? #matcher_combinators.core.InAnyOrder{:expected [1 2]} [2]))"
                `(sut/expect () :to-change [2] :from (matchers/in-any-order [1 2]) :to [2] :with ~'match?)
 
                "`from` is not allowed to equal `to`: (matcher-combinators.matchers/in-any-order [1 2])"


### PR DESCRIPTION
## Brief

#32 introduced a `pred-sym-failure`; which is a printed when the pred-symbol assertion fails; the assertion responsible for asserting `from` equals `to-change` at before the body is evaluated).

The explanation-str was mistaken though; it refers to `to`.
<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
