### PR TITLE
Add kaocha focus file plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A collection of test helpers.
 
 * `nedap.utils.test.api/expect` allows you to assert side effects in code. look at [examples in the tests](https://github.com/nedap/utils.test/blob/55021bf884fb06aa3cb9d2706ffe6816a2923e45/test/unit/nedap/utils/test/api.cljc#L119-L123).
 
+* `nedap.kacoha.focus-file-plugin` Kaocha plugin which adds `--focus-file` cli-option. Can be used to test a specific file rather than a specific file.
+
 ## Installation
 
 ```clojure
@@ -21,7 +23,8 @@ A collection of test helpers.
 ## ns organisation
 
  - `nedap.utils.test.api` 
- - `nedap.utils.test.matchers` matcher-combinators matchers
+ - `nedap.utils.test.matchers` [matcher-combinators](https://github.com/nubank/matcher-combinators) matchers
+ - `nedap.kaocha` [koacha](https://github.com/lambdaisland/kaocha) plugins
 
 ## Documentation
 

--- a/project.clj
+++ b/project.clj
@@ -73,20 +73,19 @@
                         :source-paths ["dev"]
                         :repl-options {:init-ns dev}}
 
-             :provided {:dependencies [[org.clojure/clojurescript "1.10.597"
-                                        :exclusions [com.cognitect/transit-clj
-                                                     com.google.code.findbugs/jsr305
-                                                     com.google.errorprone/error_prone_annotations
-                                                     org.clojure/tools.reader]]
-                                       [com.cognitect/transit-clj "0.8.313" #_"transitive"]
-                                       [com.fasterxml.jackson.core/jackson-core "2.10.3" #_"transitive"]
-                                       [com.google.code.findbugs/jsr305 "3.0.2" #_"transitive"]
-                                       [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
-                                       [com.google.guava/guava "25.1-jre" #_"transitive"]
-                                       [com.google.protobuf/protobuf-java "3.4.0" #_"transitive"]
-                                       [nubank/matcher-combinators "3.1.4"
-                                        :exclusions [org.clojure/spec.alpha
-                                                     commons-codec]]]}
+             :provided {:dependencies [[lambdaisland/kaocha "1.0.861"]
+                                       [nubank/matcher-combinators "3.1.4"]
+                                       [org.clojure/clojurescript "1.10.597"]]
+                        :managed-dependencies [[com.cognitect/transit-clj "0.8.313"]
+                                               [com.fasterxml.jackson.core/jackson-core "2.10.3"]
+                                               [com.google.code.findbugs/jsr305 "3.0.2"]
+                                               [com.google.errorprone/error_prone_annotations "2.1.3"]
+                                               [com.google.guava/guava "25.1-jre"]
+                                               [com.google.protobuf/protobuf-java "3.4.0"]
+                                               [commons-codec "1.11"]
+                                               [io.aviso/pretty "0.1.37"]
+                                               [org.clojure/spec.alpha "0.2.187"]
+                                               [org.clojure/tools.cli "1.0.194"]]}
 
              :check    {:global-vars  {*unchecked-math* :warn-on-boxed
                                        ;; avoid warnings that cannot affect production:

--- a/src/nedap/kaocha/focus_file_plugin.clj
+++ b/src/nedap/kaocha/focus_file_plugin.clj
@@ -1,0 +1,19 @@
+(ns nedap.kaocha.focus-file-plugin
+  "A plugin adding `focus-file` to focus on filename instead of ns."
+  (:require
+   [kaocha.plugin :as p]))
+
+(defn- accumulate [m k v]
+  (update m k (comp vec distinct (fnil conj [])) v))
+
+(p/defplugin nedap.kaocha/focus-file-plugin
+  (cli-options [opts]
+    (conj opts [nil "--focus-file FILE" "Only run tests in this file, skip others." :assoc-fn accumulate]))
+
+  (config [{{:keys [focus-file]} :kaocha/cli-options
+            :as config}]
+    (if (seq focus-file)
+      (-> config
+          (update :kaocha/tests #(mapv (fn [x] (assoc x :kaocha/test-paths focus-file)) %))
+          (update :kaocha/cli-options dissoc :focus-file))
+     config)))


### PR DESCRIPTION
## Brief

Allows running tests in a specific file rather than ns. Internally we use this to split tests with CirclecCI and kaocha. see https://circleci.com/docs/2.0/parallelism-faster-jobs/.

Kaocha runs on the JVM (although it can run cljs tests!); so the plugin is only clj.

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

TBD
<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
