### PR TITLE
Fetch from GitHub instead of JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,18 +107,12 @@ workflows:
           name: "Ensure artifact isolation, inform of boxed math"
           jdk_version: openjdk8
           lein_test_command: lein with-profile -dev,+check check
-          context:
-            - Github
           <<: *test_code_filters
       - cloverage:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-          context:
-            - Github
           <<: *test_code_filters
       - test_cljs_code:
-          context:
-            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, plain"
@@ -127,8 +121,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context:
-            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with production-like compiler flags"
@@ -137,8 +129,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context:
-            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, plain"
@@ -147,8 +137,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context:
-            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, with production-like compiler flags"
@@ -157,8 +145,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context:
-            - Github
           <<: *test_code_filters
       - deploy:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,6 @@ jobs:
           name: Perform pre-release sanity check
           command: lein with-profile -dev,+ci,+ncrw run -m nedap.ci.release-workflow.api sanity-check
       - run:
-          name: release to JFrog
-          command: lein deploy
-      - run:
           name: release to Clojars
           command: lein deploy clojars          
 
@@ -110,15 +107,18 @@ workflows:
           name: "Ensure artifact isolation, inform of boxed math"
           jdk_version: openjdk8
           lein_test_command: lein with-profile -dev,+check check
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - cloverage:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - test_cljs_code:
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, plain"
@@ -127,7 +127,8 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with production-like compiler flags"
@@ -136,7 +137,8 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, plain"
@@ -145,7 +147,8 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, with production-like compiler flags"
@@ -154,10 +157,14 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
+          context:
+            - Github
           <<: *test_code_filters
       - deploy:
-          context: JFrog
+          context:
+            - Clojars
+            - Github
+            - GPG
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - test_cljs_code

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "1.8.0-alpha1"]
+[com.nedap.staffing-solutions/utils.test "1.8.0-alpha2"]
 ```
 
 ## ns organisation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of test helpers.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.test "1.8.0"]
+[com.nedap.staffing-solutions/utils.test "1.8.0-alpha1"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.test "1.8.0-alpha1"
+(defproject com.nedap.staffing-solutions/utils.test "1.8.0-alpha2"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.1"]]
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.test "1.8.0"
+(defproject com.nedap.staffing-solutions/utils.test "1.8.0-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.1"]]
 

--- a/project.clj
+++ b/project.clj
@@ -14,13 +14,9 @@
 
   :signing {:gpg-key "releases-staffingsolutions@nedap.com"}
 
-  :repositories {"releases" {:url      "https://nedap.jfrog.io/nedap/staffing-solutions/"
-                             :username :env/artifactory_user
-                             :password :env/artifactory_pass}}
-
-  :repository-auth {#"https://nedap.jfrog\.io/nedap/staffing-solutions/"
-                    {:username :env/artifactory_user
-                     :password :env/artifactory_pass}}
+  :repositories {"github" {:url "https://maven.pkg.github.com/nedap/*"
+                           :username "github"
+                           :password :env/github_token}}
 
   :deploy-repositories {"clojars" {:url      "https://clojars.org/repo"
                                    :username :env/clojars_user
@@ -54,9 +50,9 @@
   ;; NOTE: deps marked with #_"transitive" are there to satisfy the `:pedantic?` option.
   :profiles {:dev      {:dependencies [[cider/cider-nrepl "0.16.0" #_"formatting-stack needs it"]
                                        [com.clojure-goes-fast/clj-java-decompiler "0.3.0"]
-                                       [com.nedap.staffing-solutions/speced.def "2.0.0"]
-                                       [com.nedap.staffing-solutions/utils.modular "2.1.0"]
-                                       [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]
+                                       [com.nedap.staffing-solutions/speced.def "2.0.1"]
+                                       [com.nedap.staffing-solutions/utils.modular "2.2.0"]
+                                       [com.nedap.staffing-solutions/utils.spec.predicates "1.2.1"]
                                        [com.stuartsierra/component "0.4.0"]
                                        [com.taoensso/timbre "4.10.0"]
                                        [criterium "0.4.5"]
@@ -110,7 +106,7 @@
                           :test-paths     ^:replace []
                           :resource-paths ^:replace []
                           :plugins        ^:replace []
-                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.13.1"]]}
+                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.14.1"]]}
 
              :ci       {:pedantic?    :abort
                         :jvm-opts     ["-Dclojure.main.report=stderr"]}})


### PR DESCRIPTION
## Brief

Fetch from GitHub instead of JFrog.

## QA plan

- [x] https://clojars.org/com.nedap.staffing-solutions/utils.test/versions/1.8.0-alpha1

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
